### PR TITLE
fix help text for the coverage tool

### DIFF
--- a/pypeline/tools/bam_stats/common.py
+++ b/pypeline/tools/bam_stats/common.py
@@ -88,16 +88,16 @@ def parse_arguments(argv, ext):
                              "the file is read from STDIN.")
     parser.add_argument("outfile", metavar="OUTPUT", nargs='?',
                         help="Filename of output table; defaults to name of "
-                             "the input BAM with a '.depths' extension. If "
-                             "set to '-' the table is printed to STDOUT.")
+                             "the input BAM with a %r extension. If "
+                             "set to '-' the table is printed to STDOUT." % ext)
     parser.add_argument("--target-name", default=None,
                         help="Name used for 'Target' column; defaults to the "
                              "filename of the BAM file.")
     parser.add_argument("--regions-file", default=None, dest="regions_fpath",
-                        help="BED file containing regions of interest; depth "
+                        help="BED file containing regions of interest; %s "
                              "is calculated only for these grouping by the "
                              "name used in the BED file, or the contig name "
-                             "if no name has been specified for a record.")
+                             "if no name has been specified for a record." % (ext.strip("."),))
     parser.add_argument('--max-contigs', default=100, type=int,
                         help="The maximum number of contigs allowed in a BAM "
                              "file. If this number is exceeded, the entire "
@@ -107,7 +107,7 @@ def parse_arguments(argv, ext):
     parser.add_argument('--ignore-readgroups',
                         default=False, action="store_true",
                         help="Ignore readgroup information in reads, and only "
-                             "provide aggreaged statistics; this is required "
+                             "provide aggregated statistics; this is required "
                              "if readgroup information is missing or partial "
                              "[default: %(default)s]")
     parser.add_argument('--overwrite-output',

--- a/pypeline/tools/bam_stats/coverage.py
+++ b/pypeline/tools/bam_stats/coverage.py
@@ -55,7 +55,9 @@ TABLE_HEADER = """# Timestamp: %s
 #             name are combined into one row, with the size representing to
 #             total of these. Note that overlapping bases are counted 2 (or
 #             more) times.
-#  Hits:      Sum of SE, PE_1, and PE_2 hits
+#  Hits:      Sum of SE, PE_1, and PE_2 hits. Note that supplementary alignments,
+#             duplicates, reads that failed QC, secondary alignments, 
+#             and unmapped reads are ignored.
 #  SE, PE_*:  Number of Single Ended, and Pair Ended (mate 1 and 2) hits
 #             overlapping the current contig or intervals. Note that a hit may
 #             be counted multiple times if it overlaps multiple intervals


### PR DESCRIPTION
* extension was hardcoded as '.depths' for coverage.
* add note in coverage header about reads that are ignored