### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from distutils.command.install_scripts import \
     install_scripts as DistutilsInstallScripts
 
 
-if (sys.version_info.major != 2) or (sys.version_info.minor != 7):
+if (sys.version_info[0] != 2) or (sys.version_info[1] != 7):
     sys.stderr.write("ERROR: Python version 2.7.x required!\n")
     sys.stderr.write("       Current version is v%s\n"
                      % (sys.version.replace("\n", " "),))


### PR DESCRIPTION
The 'major' and 'minor' attributes to sys.version_info were newly added in Python 2.7. If you're using 2.6 or earlier, it is a tuple with no named attributes, which will cause an attribute error when running this setup (and no actual message to tell people they're using the wrong version).