### PR TITLE
use available CPUs rather than total CPUs

### DIFF
--- a/paleomix/common/procs.py
+++ b/paleomix/common/procs.py
@@ -24,6 +24,7 @@
 Tools used for working with subprocesses.
 """
 
+import os
 import sys
 import time
 from subprocess import DEVNULL, PIPE, STDOUT, Popen
@@ -99,3 +100,9 @@ def join_procs(procs, out=sys.stderr):
         out.flush()
 
     return return_codes
+
+
+def max_processes():
+    """Returns the number of processes that can be run simultaneously"""
+
+    return max(1, len(os.sched_getaffinity(0)))

--- a/paleomix/pipelines/bam/config.py
+++ b/paleomix/pipelines/bam/config.py
@@ -20,12 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-import multiprocessing
 import os
 
 import paleomix
 import paleomix.common.logging
 from paleomix.common.argparse import SUPPRESS, ArgumentParser
+from paleomix.common.procs import max_processes
 from paleomix.common.resources import add_copy_example_command
 
 _DEFAULT_CONFIG_FILES = [
@@ -91,25 +91,25 @@ def add_run_command(subparsers):
     group.add_argument(
         "--max-threads",
         type=int,
-        default=max(2, multiprocessing.cpu_count()),
+        default=max(2, max_processes()),
         help="Max number of threads to use in total",
     )
     group.add_argument(
         "--adapterremoval-max-threads",
         type=int,
-        default=min(3, multiprocessing.cpu_count()),
+        default=min(3, max_processes()),
         help="Max number of threads to use per AdapterRemoval instance",
     )
     group.add_argument(
         "--bowtie2-max-threads",
         type=int,
-        default=max(1, min(8, multiprocessing.cpu_count() // 2)),
+        default=max(1, min(8, max_processes() // 2)),
         help="Max number of threads to use per Bowtie2 instance",
     )
     group.add_argument(
         "--bwa-max-threads",
         type=int,
-        default=max(1, min(8, multiprocessing.cpu_count() // 2)),
+        default=max(1, min(8, max_processes() // 2)),
         help="Max number of threads to use per BWA instance",
     )
 

--- a/paleomix/pipelines/phylo/config.py
+++ b/paleomix/pipelines/phylo/config.py
@@ -20,12 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-import multiprocessing
 import os
 
 import paleomix
 import paleomix.common.logging
 from paleomix.common.argparse import SUPPRESS, ArgumentParser
+from paleomix.common.procs import max_processes
 
 _DEFAULT_CONFIG_FILES = [
     "/etc/paleomix/phylo_pipeline.ini",
@@ -60,7 +60,7 @@ def build_parser():
     group.add_argument(
         "--max-threads",
         type=int,
-        default=max(2, multiprocessing.cpu_count()),
+        default=max(2, max_processes()),
         help="Max number of threads to use in total",
     )
     group.add_argument(

--- a/paleomix/pipelines/zonkey/config.py
+++ b/paleomix/pipelines/zonkey/config.py
@@ -20,11 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-import multiprocessing
-
 import paleomix
 import paleomix.common.logging
 from paleomix.common.argparse import SUPPRESS, ArgumentParser
+from paleomix.common.procs import max_processes
 
 _RUN_USAGE = """%(prog)s [..] <database.tar> <samples.txt> [destination]
        %(prog)s [..] <database.tar> <sample.bam> [destination]
@@ -149,7 +148,7 @@ def add_run_command(subparsers):
     group.add_argument(
         "--max-threads",
         type=int,
-        default=max(2, multiprocessing.cpu_count()),
+        default=max(2, max_processes()),
         help="Maximum number of threads to use",
     )
     group.add_argument(


### PR DESCRIPTION
This improves compatibility with workload managers like Slurm