### PR TITLE
backport switch to samtools for basic operations

### DIFF
--- a/paleomix/nodes/commands.py
+++ b/paleomix/nodes/commands.py
@@ -115,9 +115,7 @@ class DepthHistogramNode(CommandNode):
 
 
 class FilterCollapsedBAMNode(CommandNode):
-    def __init__(
-        self, config, input_bams, output_bam, keep_dupes=True, dependencies=()
-    ):
+    def __init__(self, input_bams, output_bam, keep_dupes=True, dependencies=()):
         merge = merge_bam_files_command(input_bams)
 
         builder = factory.new("rmdup_collapsed")

--- a/paleomix/nodes/picard.py
+++ b/paleomix/nodes/picard.py
@@ -26,7 +26,7 @@ import os
 import paleomix.common.system
 import paleomix.common.versions as versions
 from paleomix.atomiccmd.builder import AtomicJavaCmdBuilder
-from paleomix.common.fileutils import describe_files, swap_ext, try_rmtree
+from paleomix.common.fileutils import swap_ext, try_rmtree
 from paleomix.node import CommandNode
 
 
@@ -98,61 +98,6 @@ class ValidateBAMNode(PicardNode):
                 builder.add_option("IGNORE", "REF_SEQ_TOO_LONG_FOR_BAI", sep="=")
         except versions.VersionRequirementError:
             pass  # Ignored here, handled elsewhere
-
-
-class MarkDuplicatesNode(PicardNode):
-    def __init__(
-        self,
-        config,
-        input_bams,
-        output_bam,
-        output_metrics=None,
-        keep_dupes=False,
-        dependencies=(),
-    ):
-        params = picard_command(config, "MarkDuplicates")
-        _set_max_open_files(params, "MAX_FILE_HANDLES")
-
-        params.set_option("OUTPUT", "%(OUT_BAM)s", sep="=")
-        params.set_option("METRICS_FILE", "%(OUT_METRICS)s", sep="=")
-        # Validation is mostly left to manual ValidateSamFile runs; required
-        # because .csi indexed BAM records can have "invalid" bins.
-        params.set_option("VALIDATION_STRINGENCY", "LENIENT", sep="=")
-        params.add_multiple_options("I", input_bams, sep="=")
-
-        if not keep_dupes:
-            # Remove duplicates from output by default to save disk-space
-            params.set_option("REMOVE_DUPLICATES", "True", sep="=", fixed=False)
-
-        output_metrics = output_metrics or swap_ext(output_bam, ".metrics")
-        params.set_kwargs(OUT_BAM=output_bam, OUT_METRICS=output_metrics)
-
-        PicardNode.__init__(
-            self,
-            command=params.finalize(),
-            description="detecting PCR duplicates in %s"
-            % (describe_files(input_bams),),
-            dependencies=dependencies,
-        )
-
-
-class MergeSamFilesNode(PicardNode):
-    def __init__(self, config, input_bams, output_bam, dependencies=()):
-        builder = picard_command(config, "MergeSamFiles")
-        builder.set_option("OUTPUT", "%(OUT_BAM)s", sep="=")
-        builder.set_option("SO", "coordinate", sep="=")
-        # Validation is mostly left to manual ValidateSamFile runs; required
-        # because .csi indexed BAM records can have "invalid" bins.
-        builder.set_option("VALIDATION_STRINGENCY", "LENIENT", sep="=")
-        builder.add_multiple_options("I", input_bams, sep="=")
-
-        builder.set_kwargs(OUT_BAM=output_bam)
-        PicardNode.__init__(
-            self,
-            command=builder.finalize(),
-            description="merging %i file(s) into %s" % (len(input_bams), output_bam),
-            dependencies=dependencies,
-        )
 
 
 ###############################################################################

--- a/paleomix/nodes/samtools.py
+++ b/paleomix/nodes/samtools.py
@@ -25,13 +25,14 @@ import os
 import paleomix.common.versions as versions
 from paleomix.atomiccmd.builder import AtomicCmdBuilder
 from paleomix.atomiccmd.command import AtomicCmd
-from paleomix.common.fileutils import reroot_path
+from paleomix.atomiccmd.sets import ParallelCmds
+from paleomix.common.fileutils import describe_files, reroot_path
 from paleomix.node import CommandNode
 
 _VERSION_REGEX = r"Version: (\d+)\.(\d+)(?:\.(\d+))?"
 
 SAMTOOLS_VERSION = versions.Requirement(
-    call=("samtools",), search=_VERSION_REGEX, checks=versions.GE(1, 3, 1)
+    call=("samtools",), search=_VERSION_REGEX, checks=versions.GE(1, 6, 0)
 )
 
 BCFTOOLS_VERSION = versions.Requirement(
@@ -150,6 +151,92 @@ class BAMIndexNode(CommandNode):
             self,
             description="creating %s index for %s" % (index_format[1:].upper(), infile),
             command=command,
+            dependencies=dependencies,
+        )
+
+
+class MarkDupNode(CommandNode):
+    def __init__(
+        self,
+        in_bams,
+        out_bam,
+        out_stats=None,
+        keep_duplicates=True,
+        dependencies=(),
+    ):
+        in_bams = tuple(in_bams)
+        if len(in_bams) > 1:
+            merge = merge_bam_files_command(in_bams)
+
+            markdup = AtomicCmdBuilder(
+                ["samtools", "markdup", "-", "%(OUT_BAM)s"],
+                IN_STDIN=merge,
+                OUT_BAM=out_bam,
+                # Stderr is piped instead of saved using -f to support samtools < v1.10
+                OUT_STDERR=out_stats,
+                CHECK_VERSION=SAMTOOLS_VERSION,
+                set_cwd=True,
+            )
+
+            threads = 2
+        elif in_bams:
+            merge = None
+            markdup = AtomicCmdBuilder(
+                ["samtools", "markdup", "%(IN_BAM)s", "%(OUT_BAM)s"],
+                IN_BAM=in_bams[0],
+                OUT_BAM=out_bam,
+                OUT_STDERR=out_stats,
+                CHECK_VERSION=SAMTOOLS_VERSION,
+                set_cwd=True,
+            )
+
+            threads = 1
+        else:
+            raise ValueError(in_bams)
+
+        if out_stats is not None:
+            markdup.add_option("-s", None)
+
+        if not keep_duplicates:
+            markdup.add_option("-r", None)
+
+        markdup = markdup.finalize()
+
+        CommandNode.__init__(
+            self,
+            command=markdup if merge is None else ParallelCmds([merge, markdup]),
+            description="marking PCR duplicates in {}".format(describe_files(in_bams)),
+            dependencies=dependencies,
+            threads=threads,
+        )
+
+
+class BAMMergeNode(CommandNode):
+    def __init__(self, input_bams, output_bam, dependencies=()):
+        in_files = tuple(input_bams)
+        if not in_files:
+            raise ValueError("no input files for samtools merge")
+        elif len(in_files) == 1:
+            # FIXME: hardlinking is faster, but could have unintended side-effects
+            cmd = AtomicCmd(
+                ["cp", "%(IN_BAM)s", "%(OUT_BAM)s"],
+                IN_BAM=in_files[0],
+                OUT_BAM=output_bam,
+            )
+        else:
+            cmd = AtomicCmdBuilder(
+                ["samtools", "merge", "%(OUT_BAM)s"],
+                OUT_BAM=output_bam,
+                CHECK_VERSION=SAMTOOLS_VERSION,
+            )
+
+            cmd.add_multiple_values(in_files)
+            cmd = cmd.finalize()
+
+        CommandNode.__init__(
+            self,
+            command=cmd,
+            description=f"merging {len(in_files)} files into {output_bam}",
             dependencies=dependencies,
         )
 

--- a/paleomix/pipelines/bam/parts/lane.py
+++ b/paleomix/pipelines/bam/parts/lane.py
@@ -231,6 +231,8 @@ class Lane:
 
     def _cleanup_options(self, aligner):
         options = {
+            # Add mate-score tag required by `samtools markdup`
+            "--add-mate-score": None,
             "--rg-id": self.tags["ID"],
             "--rg": [
                 "%s:%s" % (tag_name, self.tags[tag_name])

--- a/paleomix/pipelines/bam/parts/prefix.py
+++ b/paleomix/pipelines/bam/parts/prefix.py
@@ -23,7 +23,7 @@
 import os
 
 from paleomix.common.utilities import safe_coerce_to_tuple
-from paleomix.nodes.picard import MergeSamFilesNode
+from paleomix.nodes.samtools import BAMMergeNode
 from paleomix.nodes.validation import DetectInputDuplicationNode
 from paleomix.pipelines.bam.nodes import index_and_validate_bam
 
@@ -57,8 +57,7 @@ class Prefix:
             self.folder, self.target, prefix["Name"] + ".validated"
         )
 
-        node = MergeSamFilesNode(
-            config=config,
+        node = BAMMergeNode(
             input_bams=list(files_and_bams),
             output_bam=output_filename,
             dependencies=self.datadup_check,

--- a/paleomix/tools/cleanup.py
+++ b/paleomix/tools/cleanup.py
@@ -203,7 +203,11 @@ def _run_cleanup_pipeline(args):
     try:
         if args.paired_end:
             # Convert input to (uncompressed) BAM and fix mate information for PE reads
-            commands.append(["samtools", "fixmate", "-O", "bam", "-", "-"])
+            command = ["samtools", "fixmate", "-O", "bam"]
+            if args.add_mate_score:
+                command.append("-m")
+
+            commands.append(command + ["-", "-"])
 
         # Cleanup / filter reads. Must be done after 'fixmate', as BWA may produce
         # hits where the mate-unmapped flag is incorrect, which 'fixmate' fixes.
@@ -284,6 +288,13 @@ def parse_args(argv):
         action="store_true",
         help="If enabled, additional processing of PE reads is carried out, including "
         "updating of mate information [Default: off]",
+    )
+    parser.add_argument(
+        "--add-mate-score",
+        default=False,
+        action="store_true",
+        help="If enabled, the -m flag is passed to 'fixmate' and mate-score tags are "
+        "added to reads [Default: off]",
     )
 
     parser.add_argument(


### PR DESCRIPTION
This removes the requirement for picard for everything but (optional) validation of BAM files.

Backports
ec11db47455ad7c486739d703e3e73d8146d5f06
7a8f65cb787b0fe05a27dbdcc7bdc3ab66599a89
c71bc654f71d61b59da30a68bd9a8e9db815ed19
8fe1f7a306061129a7b5fee6dc6088b560387168