### PR TITLE
fix makefile error when using bwa mem

### DIFF
--- a/paleomix/pipelines/bam/parts/reads.py
+++ b/paleomix/pipelines/bam/parts/reads.py
@@ -101,7 +101,7 @@ class Reads:
         # Always convert output to Phred+33, to normalize ARv2 and ARv3 behavior
         ar_options["--qualitybase"] = self.quality_offset
         ar_options["--qualitybase-output"] = "33"
-        self.quality_offset = "33"
+        self.quality_offset = 33
 
         init_args = {
             "output_prefix": os.path.join(self.folder, "reads"),


### PR DESCRIPTION
This regression was introduced when dropping support for non-Phred+33 FASTQ files for bwa mem.

This fixes #126